### PR TITLE
TICKET 1.3: Slack-Initiated Case Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Buildathon 26
+
+Bug investigation pipeline: GitHub issues → Slack notifications, case state machine, and (optional) AI agents.
+
+## Quick start
+
+The main app is a **Next.js frontend** that runs the web UI, API routes, Slack integration, and GitHub webhooks.
+
+1. **Clone and enter the frontend**
+   ```bash
+   git clone <this-repo>
+   cd buildathon26/frontend
+   ```
+
+2. **Follow [frontend/README.md](frontend/README.md)** for:
+   - Environment variables (`.env` + `.env.local`)
+   - Database setup (Prisma + SQLite)
+   - Slack & GitHub webhook (optional for full features)
+   - `npm install` and `npm run dev`
+
+3. Open **http://localhost:3000**
+
+## Repo layout
+
+| Path | Description |
+|------|-------------|
+| **frontend/** | Next.js app (UI, APIs, Slack, GitHub webhook, Prisma DB). **This is what you run.** |
+| **backend/** | Optional Python agents (triage, codebase search). See [backend/README.md](backend/README.md). |

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -15,5 +15,8 @@ SLACK_SIGNING_SECRET=your-signing-secret
 # GitHub App / webhook (TICKET-1.1)
 GITHUB_WEBHOOK_SECRET=your-github-webhook-secret
 
+# Slack-initiated cases (TICKET-1.3): default repo for #123 style refs and "Create GitHub issue" link
+# GITHUB_DEFAULT_REPO=owner/repo
+
 # SQLite for case records
 DATABASE_URL="file:./dev.db"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -55,6 +55,17 @@ To have **new GitHub issues** create a case in the DB and post to Slack, GitHub 
 
 The app only acts on **issues.opened** (creates case, posts to Slack). Other events (e.g. `pull_request`, `issue_comment`) are accepted and logged but not processed.
 
+#### Slack @mention — start a case from Slack (TICKET-1.3)
+
+Users can start a BugPilot case by **@mentioning the app** in a channel or thread with a bug description. Optionally reference a GitHub issue (e.g. `#123` or `owner/repo#123`).
+
+1. **Slack app** → **Event Subscriptions** → **Enable Events** → **Request URL:** `https://<your-public-host>/api/slack/events` (use ngrok for local dev).
+2. Under **Subscribe to bot events**, add **app_mention**. Save.
+3. Reinstall the app to the workspace if prompted.
+4. Optional: set `GITHUB_DEFAULT_REPO=owner/repo` in `.env.local` so `#123` in the message resolves to that repo, and so the "Create GitHub issue" button can link to a new-issue URL.
+
+When someone mentions the bot, the app creates a case (with `sourceType: "slack"`), stores the message and Slack user/channel/thread, and replies in the same thread with action buttons (Investigate, Assign Human, Create GitHub issue if no issue linked, etc.). The case appears in the dashboard and the thread is the timeline.
+
 ### 3. Database
 
 ```bash

--- a/frontend/app/api/cases/route.ts
+++ b/frontend/app/api/cases/route.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/db"
 
 /**
  * GET /api/cases
- * Returns list of cases (id, state, title, repo, createdAt) so you can copy a case ID for testing.
+ * Returns list of cases (id, state, title, repo, sourceType, createdAt) for dashboard.
  */
 export async function GET() {
   try {
@@ -15,6 +15,9 @@ export async function GET() {
         state: true,
         title: true,
         repo: true,
+        sourceType: true,
+        slackChannelId: true,
+        slackThreadTs: true,
         createdAt: true,
       },
     })

--- a/frontend/app/api/slack/events/route.ts
+++ b/frontend/app/api/slack/events/route.ts
@@ -1,0 +1,253 @@
+import { NextResponse } from "next/server"
+import { verifySlackSignature } from "@/lib/slack"
+import {
+  postBlocksInThread,
+  buildSlackCaseBlocks,
+  type SlackCasePayload,
+} from "@/lib/slack"
+import { prisma } from "@/lib/db"
+import { recordInitialState } from "@/lib/case-state-machine"
+import { recordIssueCreated } from "@/lib/issue-state"
+
+type SlackEvent = {
+  type: string
+  user?: string
+  text?: string
+  ts?: string
+  channel?: string
+  thread_ts?: string
+  bot_id?: string
+}
+
+type SlackEventsPayload = {
+  type: "url_verification" | "event_callback"
+  challenge?: string
+  event?: SlackEvent
+  event_id?: string
+}
+
+const MAX_TITLE_LEN = 200
+const MAX_SUMMARY_LEN = 500
+
+/** Strip bot mention like <@U123ABC> from message text. */
+function stripBotMention(text: string, botUserId?: string): string {
+  let out = text.trim()
+  // Remove <@U123> style mentions (optionally only our bot)
+  out = out.replace(/<@([A-Z0-9]+)>/g, (match, id) => {
+    if (botUserId && id !== botUserId) return match
+    return ""
+  })
+  return out.replace(/\s+/g, " ").trim()
+}
+
+/**
+ * Parse message for GitHub issue reference: #123 or owner/repo#123 or full URL.
+ * Returns { repo, issueNumber } or null.
+ */
+function parseIssueRef(
+  text: string,
+  defaultRepo: string | null
+): { repo: string; issueNumber: number } | null {
+  // Full URL: https://github.com/owner/repo/issues/123
+  const urlMatch = text.match(
+    /github\.com\/([^/]+\/[^/]+)\/issues\/(\d+)/i
+  )
+  if (urlMatch) {
+    return { repo: urlMatch[1], issueNumber: parseInt(urlMatch[2], 10) }
+  }
+  // owner/repo#123
+  const repoHashMatch = text.match(/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)#(\d+)/)
+  if (repoHashMatch) {
+    return {
+      repo: repoHashMatch[1],
+      issueNumber: parseInt(repoHashMatch[2], 10),
+    }
+  }
+  // #123 (use default repo from env)
+  const hashMatch = text.match(/#(\d+)/)
+  if (hashMatch && defaultRepo) {
+    return {
+      repo: defaultRepo,
+      issueNumber: parseInt(hashMatch[1], 10),
+    }
+  }
+  return null
+}
+
+async function handleAppMention(event: SlackEvent): Promise<void> {
+  const channel = event.channel
+  const user = event.user
+  const text = event.text ?? ""
+  const ts = event.ts ?? ""
+  const threadTs = event.thread_ts ?? ts
+
+  console.log("[Slack events] handleAppMention", { channel, user, ts, text: text.slice(0, 80) })
+
+  if (!channel || !ts) {
+    console.warn("[Slack events] app_mention missing channel or ts", event)
+    return
+  }
+
+  const defaultRepo = process.env.GITHUB_DEFAULT_REPO?.trim() ?? null
+  const messageText = stripBotMention(text)
+  const issueRef = parseIssueRef(messageText, defaultRepo)
+
+  const title =
+    messageText.slice(0, MAX_TITLE_LEN) ||
+    "Slack case"
+  const summary =
+    messageText.length > MAX_SUMMARY_LEN
+      ? messageText.slice(0, MAX_SUMMARY_LEN) + "…"
+      : messageText || "No description."
+
+  let caseRecord: {
+    id: string
+    repo: string | null
+    githubIssueId: number | null
+    githubIssueUrl: string | null
+  }
+
+  if (issueRef) {
+    const repoFullName = issueRef.repo
+    const githubIssueUrl = `https://github.com/${repoFullName}/issues/${issueRef.issueNumber}`
+    try {
+      caseRecord = await prisma.case.create({
+        data: {
+          repo: repoFullName,
+          githubIssueId: issueRef.issueNumber,
+          githubIssueUrl,
+          title,
+          body: messageText || undefined,
+          state: "NEW",
+          sourceType: "slack",
+          slackUserId: user ?? undefined,
+          slackChannelId: channel,
+          slackThreadTs: threadTs,
+          slackMessageText: messageText || undefined,
+        },
+      })
+      await recordInitialState(caseRecord.id)
+    } catch (e: unknown) {
+      const code = (e as { code?: string })?.code
+      if (code === "P2002") {
+        const existing = await prisma.case.findFirst({
+          where: { repo: repoFullName, githubIssueId: issueRef.issueNumber },
+        })
+        if (existing) {
+          await prisma.case.update({
+            where: { id: existing.id },
+            data: {
+              slackChannelId: channel,
+              slackThreadTs: threadTs,
+              slackUserId: user ?? undefined,
+              slackMessageText: messageText || undefined,
+            },
+          })
+          caseRecord = existing
+        } else {
+          throw e
+        }
+      } else {
+        throw e
+      }
+    }
+  } else {
+    caseRecord = await prisma.case.create({
+      data: {
+        repo: null,
+        githubIssueId: null,
+        title,
+        body: messageText || undefined,
+        state: "NEW",
+        sourceType: "slack",
+        slackUserId: user ?? undefined,
+        slackChannelId: channel,
+        slackThreadTs: threadTs,
+        slackMessageText: messageText || undefined,
+      },
+    })
+    await recordInitialState(caseRecord.id)
+  }
+
+  recordIssueCreated(channel, threadTs)
+
+  const payload: SlackCasePayload = {
+    caseId: caseRecord.id,
+    title,
+    summary,
+    repoLink: caseRecord.repo
+      ? `https://github.com/${caseRecord.repo}`
+      : null,
+    hasGithubIssue: caseRecord.githubIssueId != null,
+  }
+  const blocks = buildSlackCaseBlocks(payload)
+  await postBlocksInThread(
+    channel,
+    threadTs,
+    blocks,
+    `Case created: ${title}`
+  )
+
+  console.log("[Slack events] case created from app_mention", {
+    caseId: caseRecord.id,
+    channel,
+    threadTs,
+    hasGithubIssue: caseRecord.githubIssueId != null,
+  })
+}
+
+/**
+ * POST /api/slack/events
+ * Slack Event Subscriptions: url_verification and app_mention (TICKET-1.3).
+ * Configure in Slack app: Event Subscriptions → Request URL = this endpoint.
+ * Subscribe to bot events: app_mention.
+ */
+export async function POST(request: Request) {
+  const rawBody = await request.text()
+  const signature = request.headers.get("x-slack-signature")
+  const requestTimestamp = request.headers.get("x-slack-request-timestamp")
+
+  const skipVerify = process.env.SKIP_SLACK_SIGNATURE_VERIFY === "1"
+  const valid =
+    skipVerify ||
+    verifySlackSignature(
+      Buffer.from(rawBody, "utf8"),
+      signature,
+      requestTimestamp
+    )
+  if (!valid) {
+    console.warn("[Slack events] 401 Invalid signature")
+    return new NextResponse("Invalid signature", { status: 401 })
+  }
+
+  let payload: SlackEventsPayload
+  try {
+    payload = JSON.parse(rawBody) as SlackEventsPayload
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  if (payload.type === "url_verification") {
+    const challenge = payload.challenge
+    if (typeof challenge !== "string") {
+      return NextResponse.json({ error: "Missing challenge" }, { status: 400 })
+    }
+    return NextResponse.json({ challenge })
+  }
+
+  if (payload.type === "event_callback") {
+    const event = payload.event
+    if (!event) {
+      return NextResponse.json({ error: "Missing event" }, { status: 400 })
+    }
+    console.log("[Slack events] event_callback", event.type, event.channel, event.ts)
+    if (event.type === "app_mention") {
+      void handleAppMention(event).catch((err) => {
+        console.error("[Slack events] handleAppMention failed", err)
+      })
+    }
+    return new NextResponse()
+  }
+
+  return new NextResponse()
+}

--- a/frontend/lib/slack.ts
+++ b/frontend/lib/slack.ts
@@ -13,11 +13,11 @@ export type IssuePayload = {
   repoFullName?: string
 }
 
-function getSlackConfig() {
+function getSlackConfig(): { token: string; channel?: string } {
   const token = process.env.SLACK_BOT_TOKEN
-  const channel = process.env.SLACK_CHANNEL_ID
-  if (!token || !channel) {
-    throw new Error("SLACK_BOT_TOKEN and SLACK_CHANNEL_ID must be set")
+  const channel = process.env.SLACK_CHANNEL_ID ?? undefined
+  if (!token) {
+    throw new Error("SLACK_BOT_TOKEN must be set")
   }
   return { token, channel }
 }
@@ -101,6 +101,9 @@ export async function postIssueToSlack(
   payload: IssuePayload
 ): Promise<{ ok: boolean; channel?: string; ts?: string; error?: string }> {
   const { token, channel } = getSlackConfig()
+  if (!channel) {
+    return { ok: false, error: "SLACK_CHANNEL_ID must be set for postIssueToSlack" }
+  }
   const blocks = buildIssueBlocks(payload)
   const res = await fetch(`${SLACK_API}/chat.postMessage`, {
     method: "POST",
@@ -248,6 +251,73 @@ export type HandoffContext = {
   title: string
   summary: string
   repoLink: string
+}
+
+/** Payload for Slack-initiated case (TICKET-1.3): reply in thread with case card + actions. */
+export type SlackCasePayload = {
+  caseId: string
+  title: string
+  summary: string
+  repoLink?: string | null
+  hasGithubIssue: boolean
+}
+
+/**
+ * Build Block Kit blocks for a Slack-initiated case: header, summary, repo link (if any), actions.
+ * If no GitHub issue linked, include "Create GitHub issue" button.
+ */
+export function buildSlackCaseBlocks(payload: SlackCasePayload): Record<string, unknown>[] {
+  const { caseId, title, summary, repoLink, hasGithubIssue } = payload
+  const blocks: Record<string, unknown>[] = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: `📋 Case created: ${title}`, emoji: true },
+    },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: summary || "_No description._" },
+    },
+  ]
+  if (repoLink) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `<${repoLink}|View repository>` },
+    })
+  }
+  const cursorOpenUrl = repoLink
+    ? (process.env.CURSOR_OPEN_URL || `https://cursor.com/open?url=${encodeURIComponent(repoLink)}`)
+    : null
+  const row1: Record<string, unknown>[] = [
+    { type: "button", text: { type: "plain_text", text: "Investigate", emoji: true }, action_id: "investigate" },
+    { type: "button", text: { type: "plain_text", text: "Assign Human", emoji: true }, action_id: "assign_human" },
+  ]
+  if (cursorOpenUrl) {
+    row1.push({
+      type: "button",
+      text: { type: "plain_text", text: "Open in Cursor", emoji: true },
+      action_id: "open_in_cursor",
+      url: cursorOpenUrl,
+    })
+  }
+  if (!hasGithubIssue) {
+    row1.push({
+      type: "button",
+      text: { type: "plain_text", text: "Create GitHub issue", emoji: true },
+      action_id: "create_github_issue",
+      value: caseId,
+    })
+  }
+  blocks.push({ type: "actions", block_id: "issue_actions", elements: row1 })
+  blocks.push({
+    type: "actions",
+    block_id: "issue_actions_2",
+    elements: [
+      { type: "button", text: { type: "plain_text", text: "Report ready", emoji: true }, action_id: "report_ready" },
+      { type: "button", text: { type: "plain_text", text: "PR opened", emoji: true }, action_id: "pr_opened" },
+      { type: "button", text: { type: "plain_text", text: "Review completed", emoji: true }, action_id: "review_completed" },
+    ],
+  })
+  return blocks
 }
 
 /**

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -8,17 +8,21 @@ datasource db {
 }
 
 model Case {
-  id              String   @id @default(cuid())
-  githubIssueId   Int
-  repo            String
-  title           String
-  body            String?
-  state           String   @default("NEW")
-  slackChannelId  String?
-  slackThreadTs   String?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-  transitions     CaseStateTransition[]
+  id                String   @id @default(cuid())
+  githubIssueId     Int?     // null for Slack-only cases until issue is created/linked
+  repo              String?  // null for Slack-only cases
+  title             String
+  body              String?
+  state             String   @default("NEW")
+  slackChannelId    String?
+  slackThreadTs     String?
+  sourceType        String   @default("github") // "github" | "slack"
+  slackUserId       String?
+  slackMessageText  String?  // original message when sourceType = slack
+  githubIssueUrl    String?  // set when issue is created/linked from Slack
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+  transitions       CaseStateTransition[]
 
   @@unique([repo, githubIssueId])
 }


### PR DESCRIPTION
Description:
Allow users to initiate a BugPilot investigation directly from Slack by mentioning the bot.

Trigger on:

User mentions https://github.com/bugpilot in a channel or thread

User provides free-form bug description

User references existing GitHub issue (e.g., #123)

Flow:

Parse Slack message

Determine if issue reference exists

If issue exists → attach to case

If no issue → offer to create GitHub issue

Create internal case

Start investigation workflow

Continue updates in same Slack thread

Include:

Original Slack message as case source

Slack user ID

Channel ID

Thread timestamp

Source type = slack

GitHub issue link (if created)

Definition of Done:

https://github.com/bugpilot mention creates new case

Optional GitHub issue creation works

Investigation starts automatically

Slack thread becomes timeline

Case appears in dashboard

Slack source stored in state